### PR TITLE
Redesign projects layout and fix theme toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ Thumbs.db
 _config_dev.yml
 .claude/
 .claudeignore
+CLAUDE.md

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -76,4 +76,4 @@
     path: /assets/projects/mnist_draw_app.gif
     size: [72, 54]
   description: >
-    Multi Layer Perseptron(MLP) and some optimizers(SGD, momentum) implemented in numpy from scratch. Trained to recognize handwritten digits from original MNIST dataset. Comes with simple drawing application to test on seld-drawn samples.
+    Multi Layer Perceptron(MLP) and some optimizers(SGD, momentum) implemented in numpy from scratch. Trained to recognize handwritten digits from original MNIST dataset. Comes with simple drawing application to test on seld-drawn samples.

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,9 +6,9 @@
 
   <div class="wrapper">
 
+    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">&#9790;</button>
     <nav class="site-nav">
        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
-       <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">&#9790;</button>
        <label for="nav-trigger">
          <span class="menu-icon">
            <svg viewBox="0 0 18 15" width="18px" height="15px">

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -35,17 +35,19 @@ layout: base
             <span class="project-date">{{ project.date }}</span>
           </div>
 
-          {%- if project.media -%}
-            {%- if project.media.size -%}
-              <img src="{{ project.media.path }}" class="project-media" style="width: {{ project.media.size[0] }}%; height: {{ project.media.size[1] }}%;" loading="lazy">
-            {%- else -%}
-              <img src="{{ project.media.path }}" class="project-media" loading="lazy">
+          <div class="project-body">
+            {%- if project.media -%}
+              {%- if project.media.size -%}
+                <img src="{{ project.media.path }}" class="project-media" style="width: {{ project.media.size[0] }}%; height: {{ project.media.size[1] }}%;" loading="lazy">
+              {%- else -%}
+                <img src="{{ project.media.path }}" class="project-media" loading="lazy">
+              {%- endif -%}
             {%- endif -%}
-          {%- endif -%}
 
-          <p class="project-description">
-            {{ project.description }}
-          </p>
+            <p class="project-description">
+              {{ project.description }}
+            </p>
+          </div>
       </li>
       
 

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -25,15 +25,15 @@ layout: base
             </a>
           {%- endif -%}
           
-          <table class="project-data-table">
-            <tbody>
-            <tr>
-              <td class="project-tools">{{ project.tools }}</td>
-              <td class="project-date">{{ project.date }}</td>
-            </tr>
-          </tbody>
-
-          </table>
+          <div class="project-meta">
+            <div class="project-tools">
+              {%- assign tools = project.tools | split: ", " -%}
+              {%- for tool in tools -%}
+                <span class="project-tool-tag">{{ tool }}</span>
+              {%- endfor -%}
+            </div>
+            <span class="project-date">{{ project.date }}</span>
+          </div>
 
           {%- if project.media -%}
             {%- if project.media.size -%}

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -28,10 +28,27 @@
   }
 }
 
-.site-nav {
+.site-header .theme-toggle {
   position: absolute;
   top: 9px;
   right: $spacing-unit * .5;
+  height: 36px;
+  display: flex;
+  align-items: center;
+
+  @media screen and (min-width: $on-medium) {
+    position: static;
+    float: right;
+    height: auto;
+    display: inline-block;
+    margin-left: 20px;
+  }
+}
+
+.site-nav {
+  position: absolute;
+  top: 9px;
+  right: $spacing-unit * 1.5;
   background-color: $background-color;
   border: 1px solid $border-color-01;
   border-radius: 5px;
@@ -73,15 +90,6 @@
     padding-bottom: 5px;
   }
 
-  .theme-toggle {
-    position: absolute;
-    right: 100%;
-    top: 0;
-    height: 36px;
-    display: flex;
-    align-items: center;
-  }
-
   .page-link {
     color: $text-color;
     line-height: $base-line-height;
@@ -100,8 +108,6 @@
     float: right;
     border: none;
     background-color: inherit;
-    display: flex;
-    align-items: center;
 
     label[for="nav-trigger"] {
       display: none;
@@ -113,16 +119,6 @@
 
     input ~ .trigger {
       display: block;
-      order: 1;
-    }
-
-    .theme-toggle {
-      order: 2;
-      position: static;
-      transform: none;
-      height: auto;
-      display: inline-block;
-      margin-left: 20px;
     }
 
     .page-link {

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -120,6 +120,27 @@ body {
     margin-bottom: 0.8em;
 }
 
+@media screen and (min-width: $on-large) {
+    .project-body {
+        display: flex;
+        flex-direction: row-reverse;
+        align-items: center;
+        gap: 1.5em;
+    }
+
+    .project-body > .project-media {
+        flex-shrink: 0;
+        width: 50% !important;
+        height: auto !important;
+        margin-bottom: 0;
+    }
+
+    .project-body > .project-description {
+        flex: 1;
+        margin-bottom: 0;
+    }
+}
+
 .theme-toggle {
     background: none;
     border: none;

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -1,6 +1,28 @@
 // Placeholder to allow defining custom styles that override everything else.
 // (Use `_sass/minima/custom-variables.scss` to override variable defaults)
 
+:root {
+    --project-tool-tag-bg: rgba(255, 191, 0, 0.25);
+    --project-tool-tag-border: rgba(255, 191, 0, 0.5);
+}
+
+@media (prefers-color-scheme: light) {
+    :root {
+        --project-tool-tag-bg: var(--minima-code-background-color);
+        --project-tool-tag-border: var(--minima-border-color-02);
+    }
+}
+
+html[data-theme="dark"] {
+    --project-tool-tag-bg: rgba(255, 191, 0, 0.25);
+    --project-tool-tag-border: rgba(255, 191, 0, 0.5);
+}
+
+html[data-theme="light"] {
+    --project-tool-tag-bg: var(--minima-code-background-color);
+    --project-tool-tag-border: var(--minima-border-color-02);
+}
+
 body {
     font-size: min(200%, 20px);
 }
@@ -58,40 +80,37 @@ body {
     text-decoration: none !important;
 }
 
-.project-data-table {
-    border-collapse: collapse;
-    border: none;
-    border-spacing: 0;
-    margin-left: 0;
-    margin-right: 0;
-    margin-bottom: 0;
-    padding-right: 0;
-    width: 100%;
-    display: table;
-
-    td, th {
-        border-collapse: collapse;
-        border: none;
-        padding-left: 0;
-        padding-right: 0;
-        margin-right: 0;
-    }
+.project-meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.4em;
+    margin-top: 0.3em;
+    margin-bottom: 0.8em;
 }
 
 .project-tools {
-    font-weight: bold;
-    margin-left: 0;
-    margin-right: 0;
-    padding-left: 0;
-    padding-right: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4em;
+    flex: 1;
+}
+
+.project-tool-tag {
+    display: inline-block;
+    font-size: 0.8em;
+    padding: 0.15em 0.55em;
+    border-radius: 4px;
+    border: 1px solid var(--project-tool-tag-border);
+    background-color: var(--project-tool-tag-bg);
+    white-space: nowrap;
 }
 
 .project-date {
-    font-style: italic;
-    text-align: right;
-    vertical-align: top;
+    font-size: 0.85em;
+    color: var(--minima-brand-color);
     white-space: nowrap;
-    padding-left: 1em;
+    margin-left: auto;
 }
 
 .project-media {

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -35,6 +35,19 @@ body {
     text-decoration: none;
 }
 
+.projects-list > li {
+    border: 1px solid var(--minima-border-color-01);
+    border-radius: 8px;
+    padding: 1.2em 1.4em;
+    margin-bottom: 1.5em;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+    &:hover {
+        border-color: var(--minima-brand-color);
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    }
+}
+
 .project-name {
     display: inline;
 }

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -117,6 +117,7 @@ body {
     display: block;
     margin-left: auto;
     margin-right: auto;
+    margin-bottom: 0.8em;
 }
 
 .theme-toggle {


### PR DESCRIPTION
## Summary

- Redesigned projects page with card-style layout (bordered cards with hover effect)
- Replaced tools data table with styled tag badges using theme-aware CSS variables
- Added responsive side-by-side media/description layout on large screens
- Moved theme toggle button outside `<nav>` for consistent positioning on mobile
- Fixed typo in project description ("Perseptron" → "Perceptron")
- Added `CLAUDE.md` to `.gitignore`
